### PR TITLE
Reset voting status when the token is transferred

### DIFF
--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -629,6 +629,11 @@ contract HONG is HONGInterface, Token, TokenCreation {
 
     function transfer(address _to, uint256 _value) returns (bool success) {
 
+        // Reset kickoff voting for the next fiscal year from this address to false
+        if(currentFiscalYear < 4){
+            votedKickoff[currentFiscalYear+1][msg.sender] = false;
+        }
+
         // Reset Freeze and Harvest voting from this address to false
         votedFreeze[msg.sender] = false;
         votedHarvest[msg.sender] = false;

--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -55,6 +55,7 @@ contract Token is TokenInterface {
 
         balances[msg.sender] -= _amount;
         balances[_to] += _amount;
+
         evTransfer(msg.sender, _to, _amount);
 
         return true;
@@ -627,6 +628,11 @@ contract HONG is HONGInterface, Token, TokenCreation {
 
 
     function transfer(address _to, uint256 _value) returns (bool success) {
+
+        // Reset Freeze and Harvest voting from this address to false
+        votedFreeze[msg.sender] = false;
+        votedHarvest[msg.sender] = false;
+
         if (isFundLocked && super.transfer(_to, _value)) {
             return true;
         } else {


### PR DESCRIPTION
Please merge #34 before this one.

This commit adds logic to remove voting from the token holder for the kickoff() (before the 4th fiscal year only), freeze() and harvest() voting. 
