### PR TITLE
Removing duplicate modifier definition

### DIFF
--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -408,10 +408,6 @@ contract HONGInterface {
 
     HONG_Creator public hongcoinCreator;
 
-
-    // Used to restrict access to certain functions to only HONG Token Holders
-    modifier onlyTokenholders {}
-
     function () returns (bool success);
 
     function kickoff(uint _fiscal) returns(bool _result);


### PR DESCRIPTION
This doesn't look right to me.  Seems like the second one would/could get picked up and basically do nothing.
