### PR TITLE
Logic to support fund flow for distribution process, and more

### DIFF
--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -521,10 +521,6 @@ contract HONG is HONGInterface, Token, TokenCreation {
      * Voting for some critical steps, on blockchain
      */
     function kickoff(uint _fiscal) onlyTokenHolders noEther returns (bool _vote) {
-        // prevent duplicate voting from the same token holder
-        if(votedKickoff[_fiscal][msg.sender] > 0){
-            throw;
-        }
 
         if(!isInitialKickoffEnabled){  // if there is no kickoff() enabled before
             // input of _fiscal have to be the first year
@@ -577,10 +573,6 @@ contract HONG is HONGInterface, Token, TokenCreation {
     }
 
     function freeze() onlyTokenHolders noEther noFreezeAtFinalFiscalYear onlyDistributionNotInProgress returns (bool _vote){
-        // prevent duplicate voting from the same token holder
-        if(votedFreeze[msg.sender] > 0){
-            throw;
-        }
 
         supportFreezeQuorum -= votedFreeze[msg.sender];
         supportFreezeQuorum += balances[msg.sender];
@@ -633,18 +625,14 @@ contract HONG is HONGInterface, Token, TokenCreation {
     }
 
     function unFreeze() onlyTokenHolders noEther returns (bool _vote){
-        // prevent duplicate voting from the same token holder
-        if(votedFreeze[msg.sender] == 0){
-            throw;
-        }
 
         if(isFreezeEnabled){
             // no change to this if the fund is freezed
             throw;
         }
 
+        supportFreezeQuorum -= votedFreeze[msg.sender];
         votedFreeze[msg.sender] = 0;
-        supportFreezeQuorum -= balances[msg.sender];
         return false;
     }
 


### PR DESCRIPTION
Added logic to support fund moving from various accounts to `ReturnAccount` in distribution process triggered by `harvest` and `freeze`.

Also enabled support for duplicate voting actions to the same decision to support the case when a token holder has more token available than the amount used for the previous vote.
