### PR TITLE
Removing fiscal parameter from the kickoff function

### DIFF
--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -496,7 +496,7 @@ contract HONGInterface {
 
     function () returns (bool success);
 
-    function kickoff(uint _fiscal);
+    function kickoff();
     function freeze();
     function unFreeze();
     function harvest();
@@ -555,7 +555,10 @@ contract HONG is HONGInterface, Token, TokenCreation {
     /*
      * Voting for some critical steps, on blockchain
      */
-    function kickoff(uint _fiscal) onlyTokenHolders noEther {
+    function kickoff() onlyTokenHolders noEther {
+        // this is the only valid fiscal year parameter, so there's no point in letting the caller pass it in.
+        // Best case is they get it wrong and we throw, worst case is the get it wrong and there's some exploit
+        uint _fiscal = currentFiscalYear + 1;
 
         if(!isInitialKickoffEnabled){  // if there is no kickoff() enabled before
             // input of _fiscal have to be the first year


### PR DESCRIPTION
Removing fiscal parameter from the kickoff function, since there is only one value that is valid at any given time.
