### PR TITLE
adding taxPaid total back into token allocation

### DIFF
--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -262,6 +262,7 @@ contract TokenCreation is TokenCreationInterface, Token, GovernanceInterface {
 
         // when the caller is paying more than 10**16 wei (0.01 Ether) per token, the extra is basically a tax.
         uint256 totalTaxLevied = weiAccepted - tokensSupplied * weiPerInitialHONG;
+        taxPaid[_tokenHolder] += totalTaxLevied;
 
         // State Changes (no external calls)
         tryToLockFund();


### PR DESCRIPTION
At some point this was lost, but it should be accumulated here so that we can properly refund users if they want a refund.  Note that a refund is a _complete_ refund of all transactions made during the ICO.  Users cannot get refunds for individual transactions.  
