### PR TITLE
Bug fix in ReturnWallet, more unit tests for kickoff, harvest, distribute

### DIFF
--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -112,7 +112,7 @@ contract OwnedAccount is ErrorHandler {
     }
 
     function payOutPercentage(address _recipient, uint _percent) internal onlyOwner noEther {
-        payOutAmount(_recipient, this.balance * (_percent/100));
+        payOutAmount(_recipient, (this.balance * _percent) / 100);
     }
 
     function payOutAmount(address _recipient, uint _amount) internal onlyOwner noEther {
@@ -321,7 +321,7 @@ contract TokenCreation is TokenCreationInterface, Token, GovernanceInterface {
             doThrow("noTokensToSell");
             return false;
         }
-
+        
         // Sell tokens in batches based on the current price.
         while (remainingWei >= weiPerLatestHONG) {
             uint tokensRequested = remainingWei / weiPerLatestHONG;

--- a/test/scenario5_freeze/scenario5_test.js
+++ b/test/scenario5_freeze/scenario5_test.js
@@ -10,7 +10,6 @@ var compiled;
 var eth;
 var nothingToAssert = function(){};
 var scenario = "Scenario 5: Freezing the fund";
-var ethToWei = function(eth) { return sandbox.web3.toWei(eth, "ether");};
 
 describe(scenario, function() {
   console.log(scenario);
@@ -86,11 +85,20 @@ describe(scenario, function() {
                                         .plus(rewardWalletBalance);
     console.log("expectedTotal: " + expectedReturnWalletBalance.toString());
 
+    done = t.logEventsToConsole(done);
     done = t.assertEventIsFired(t.hong.evFreeze(), done);
     t.validateTransactions([
       function() { return t.hong.voteToFreezeFund({from: users.fellow1})},
       function() { 
         console.log("Validating fellow 1 voted to freeze...")
+        var expectedVotes = tokens1;
+        t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
+        t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
+      },
+      
+      function() { return t.hong.voteToFreezeFund({from: users.fellow1})},
+      function() { 
+        console.log("Validating fellow 1 voted to freeze (duplicate vote) ...")
         var expectedVotes = tokens1;
         t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");

--- a/test/utils.js
+++ b/test/utils.js
@@ -51,6 +51,10 @@ module.exports = {
       );
   },
 
+  sleepFor : function( seconds ){
+    this.sleepUntil(this.now() + seconds);
+  },
+
   sleepUntil : function( deadline ){
     console.log("Sleeping for " + (deadline - this.now()) + "s");
     while(this.now() < deadline){ /* do nothing */ } 
@@ -128,7 +132,7 @@ module.exports = {
     if (!exp) {
       done(new Error("Failed the '" + msg + "' check"));
       this.sandbox.stop(done);
-      this.assert(false, msg); // force an exception
+      assert(false, msg); // force an exception
     }
   },
 
@@ -140,6 +144,9 @@ module.exports = {
     return this.sandbox.web3.toBigNumber(ethNumber);
   },
 
+  assertException : function(receipt, done) {
+    this.assertTrue(receipt.exception, done, "expected exception");
+  },
 
   assertEventIsFiredByName : function (eventType, done, eventName) {
     return this.assertEventIsFired(eventType, done, function(event) {
@@ -231,10 +238,9 @@ module.exports = {
       var txHash = nextTx();
       // console.log("Wating for tx " + txHash);
       var that = this;
-      this.helper.waitForReceipt(this.sandbox.web3, txHash, function(err, receipt) {
-          // console.log("tx done " + txHash);
+      this.helper.waitForSandboxReceipt(this.sandbox.web3, txHash, function(err, receipt) {
           if (err) return done(err);
-          nextValidation();
+          nextValidation(receipt);
           that.validateTransactions(txAndValidation, done);
       });
   },


### PR DESCRIPTION
I think this is the last of the integer division problems.  I previous misread the docs about arbitrary precision in constant expressions and thought it applied to all expressions.  It doesn't.  :)  I also when through the code and looked at all instances of the divide operator to make sure there aren't any of those issues left.  

We now have 55 unit tests, covering 5 different scenarios, that cover most (but not all) of the cases that were originally outlined.
