### PR TITLE
Update contract configurations

### DIFF
--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -64,7 +64,7 @@ contract TokenInterface is ErrorHandler {
 
     event evTransfer(address msg_sender, uint msg_value, address indexed _from, address indexed _to, uint256 _amount);
 
-    // Modifier that allows only shareholders to trigger
+    // Modifier that allows only token holders to trigger
     modifier onlyTokenHolders {
         if (balanceOf(msg.sender) == 0) doThrow("onlyTokenHolders"); else {_}
     }
@@ -504,7 +504,6 @@ contract TokenCreation is TokenCreationInterface, Token, GovernanceInterface {
         }
 
         // if we've reached the 60 day mark, try to lock the fund
-        // TEST closingTimeExtensionPeriod = 30 days
         if (!isFundLocked && !isDaySixtyChecked && (now >= (closingTime + closingTimeExtensionPeriod))) {
             if (isMinTokensReached()) {
                 // Case C
@@ -673,7 +672,6 @@ contract HONG is HONGInterface, Token, TokenCreation {
                 return;
             }
 
-            // TEST lastKickoffDateBuffer = 304 days
             if(lastKickoffDate + lastKickoffDateBuffer < now){ // 2 months from the end of the fiscal year
                 // accept voting
             }else{

--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -395,8 +395,7 @@ contract TokenCreation is TokenCreationInterface, Token, GovernanceInterface {
         var tmpTaxPaidBySender = taxPaid[msg.sender];
         var tmpSenderBalance = balances[msg.sender];
 
-        var transactionCost = 0; // TODO possibly there is some transaction cost for the refund
-        var amountToRefund = tmpWeiGiven - transactionCost;
+        var amountToRefund = tmpWeiGiven;
 
         // 3: state changes.
         balances[msg.sender] = 0;

--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -26,6 +26,9 @@ contract HongConfiguration {
 
     uint public closingTime;
     uint public weiPerInitialHONG = 10**16;
+    string public name = "HONG";
+    string public symbol = "Ħ";
+    uint8 public decimals = 0;
     uint public maxBountyTokens = 2 * MILLION;
     uint public closingTimeExtensionPeriod = 30 days;
     uint public minTokensToCreate = 100 * MILLION;
@@ -321,7 +324,7 @@ contract TokenCreation is TokenCreationInterface, Token, GovernanceInterface {
             doThrow("noTokensToSell");
             return false;
         }
-        
+
         // Sell tokens in batches based on the current price.
         while (remainingWei >= weiPerLatestHONG) {
             uint tokensRequested = remainingWei / weiPerLatestHONG;
@@ -348,7 +351,7 @@ contract TokenCreation is TokenCreationInterface, Token, GovernanceInterface {
             remainingWei = msg.value - weiAccepted;
             tokensAvailable = tokensAvailableAtCurrentTier();
         }
-        
+
         // the caller will still pay this amount, even though it didn't buy any tokens.
         weiGiven[_tokenHolder] += remainingWei;
 
@@ -626,7 +629,7 @@ contract HONG is HONGInterface, Token, TokenCreation {
         if (address(managementFeeWallet) == 0)
             doThrow("managementFeeWallet:0");
     }
-    
+
     function () returns (bool success) {
         if (!isFromManagedAccount()) {
             // We do not accept donation here. Any extra amount sent to us after fund locking process, will be refunded

--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -45,12 +45,12 @@ contract HongConfiguration {
 }
 
 contract ErrorHandler {
-    // uint public errorCount = 0;
     event evRecord(address msg_sender, uint msg_value, string eventType, string message);
     function doThrow(string message) internal {
-        // errorCount++;
         evRecord(msg.sender, msg.value, "Error", message);
-        // throw;
+        if(true){ // TODO some configurable parameter to switch whether it is in testing mode
+            throw;
+        }
     }
 }
 


### PR DESCRIPTION
- Adding `name`, `symbol`, `decimals` values in the contract to support auto populate contract details for token watchers
- Changing default behaviour of `doThrow` to `throw` instead of saving a log message. (We may further enhance this with a `bool` value to indicate is_testing or not)
- clean up/ update comment
