### PR TITLE
Rename transfer function

### DIFF
--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -60,7 +60,7 @@ contract TokenInterface is ErrorHandler {
     uint256 public tokensCreated;
 
     function balanceOf(address _owner) constant returns (uint256 balance);
-    function transferMyTokens(address _to, uint256 _amount) returns (bool success);
+    function transfer(address _to, uint256 _amount) returns (bool success);
 
     event evTransfer(address msg_sender, uint msg_value, address indexed _from, address indexed _to, uint256 _amount);
 
@@ -80,7 +80,7 @@ contract Token is TokenInterface {
         return balances[_owner];
     }
 
-    function transferMyTokens(address _to, uint256 _amount) noEther returns (bool success) {
+    function transfer(address _to, uint256 _amount) noEther returns (bool success) {
         if (_amount <= 0) return false;
         if (balances[msg.sender] < _amount) return false;
         if (balances[_to] + _amount < balances[_to]) return false;
@@ -783,7 +783,7 @@ contract HONG is HONGInterface, Token, TokenCreation {
         evMgmtInvestProject(msg.sender, msg.value, _projectWallet, _amount, true);
     }
 
-    function transferMyTokens(address _to, uint256 _value) returns (bool success) {
+    function transfer(address _to, uint256 _value) returns (bool success) {
 
         // Update kickoff voting record for the next fiscal year for an address, and the total quorum
         if(currentFiscalYear < 4){
@@ -813,7 +813,7 @@ contract HONG is HONGInterface, Token, TokenCreation {
             votedHarvest[msg.sender] = 0;
         }
 
-        if (isFundLocked && super.transferMyTokens(_to, _value)) {
+        if (isFundLocked && super.transfer(_to, _value)) {
             return true;
         } else {
             if(!isFundLocked){

--- a/test/scenario1/scenario1_test.js
+++ b/test/scenario1/scenario1_test.js
@@ -52,7 +52,7 @@ describe('HONG Contract Suite', function() {
       t.createContract(compiled, done, endDate, 1*SECOND, kickoffDelay);
     });
   });
-  
+
   describe("ICO Period", function() {
     /*
     TestCase: check-tokensAvail
@@ -184,7 +184,7 @@ describe('HONG Contract Suite', function() {
     it('check token price @ tier 0', function(done) {
       checkPriceForTokens(done, users.fellow7, 1, 100);
     });
-    
+
     /*
      * Test "round down" feature (not issuing any tokens for extra ether)
      */
@@ -276,7 +276,7 @@ describe('HONG Contract Suite', function() {
           }],
           done);
     });
-    
+
     it ('does not allow new token purchase when fund it locked', function(done) {
       console.log("[does not allow new token purchase when fund it locked]");
       var buyer = users.fellow1;
@@ -284,16 +284,16 @@ describe('HONG Contract Suite', function() {
       var previousTokensCreated = t.hong.tokensCreated();
       done = t.assertEventIsFiredByName(t.hong.evRecord(), done, "notLocked");
       t.validateTransactions([
-        function() { 
+        function() {
             return t.buyTokens(buyer, 1*eth);
         },
-        function() { 
+        function() {
           t.assertEqualN(previousBalance, t.hong.balanceOf(buyer), done, "buyer tokens");
           t.assertEqualN(previousTokensCreated, t.hong.tokensCreated(), done, "tokens created");
           // TODO: The contract should not accept the ether, but it will until doThrow actaully throws
         }], done);
     });
-    
+
     it('allow bounty tokens to be issued by owner', function(done) {
       console.log("[allow bounty tokens to be issued by owner]");
       var recipeint = users.fellow2;
@@ -303,13 +303,13 @@ describe('HONG Contract Suite', function() {
       done = t.assertEventIsFired(t.hong.evMgmtIssueBountyToken(), done);
       t.validateTransactions([
           function() { return t.hong.mgmtIssueBountyToken(recipeint, bountyTokensToIssue, {from: ownerAddress}); },
-          function() { 
+          function() {
             t.assertEqualN(previousBalance + bountyTokensToIssue, t.hong.balanceOf(recipeint), done, "bounty issued");
             t.assertEqualN(previousBountyTokens + bountyTokensToIssue, t.hong.bountyTokensCreated(), done, "bounty tokens created");
           }
         ], done);
     });
-    
+
     it('DOES NOT allow bounty tokens to be issued by non-owner', function(done) {
       console.log("[DOES NOT allow bounty tokens to be issued by non-owner]");
       var recipeint = users.fellow2;
@@ -317,52 +317,52 @@ describe('HONG Contract Suite', function() {
       var previousBalance = t.asNumber(t.hong.balanceOf(recipeint));
       var previousBountyTokens = t.asNumber(t.hong.bountyTokensCreated());
       var bountyTokensToIssue = 100;
-      
+
       done = t.assertEventIsFiredByName(t.hong.evRecord(), done, "onlyManagementBody");
       t.validateTransactions([
           function() { return t.hong.mgmtIssueBountyToken(recipeint, bountyTokensToIssue, {from: nonOwner}); },
-          function() { 
+          function() {
             t.assertEqualN(previousBalance, t.hong.balanceOf(recipeint), done, "bounty not issued");
             t.assertEqualN(previousBountyTokens, t.hong.bountyTokensCreated(), done, "bounty tokens created");
           }
         ], done);
     });
-    
+
     it('DOES NOT allow more than maxBountyTokens to be issued', function(done) {
       console.log("[DOES NOT allow more than maxBountyTokens to be issued]");
       var recipeint = users.fellow2;
       var previousBalance = t.asNumber(t.hong.balanceOf(recipeint));
       var previousBountyTokens = t.asNumber(t.hong.bountyTokensCreated());
       var bountyTokensToIssue = 2000000 - previousBountyTokens + 1; // one too many
-      
+
       done = t.assertEventIsFiredByName(t.hong.evRecord(), done, "hitMaxBounty");
       t.validateTransactions([
           function() { return t.hong.mgmtIssueBountyToken(recipeint, bountyTokensToIssue, {from: ownerAddress}); },
-          function() { 
+          function() {
             t.assertEqualN(previousBalance, t.hong.balanceOf(recipeint), done, "bounty not issued");
             t.assertEqualN(previousBountyTokens, t.hong.bountyTokensCreated(), done, "bounty tokens created");
           }
         ], done);
     });
-    
+
     it('allows maxBountyTokens to be issued', function(done) {
       console.log("[allows maxBountyTokens to be issued]");
       var recipeint = users.fellow2;
       var previousBalance = t.asNumber(t.hong.balanceOf(recipeint));
       var previousBountyTokens = t.asNumber(t.hong.bountyTokensCreated());
       var bountyTokensToIssue = 2000000 - previousBountyTokens; // just right
-      
+
       done = t.assertEventIsFired(t.hong.evMgmtIssueBountyToken(), done);
       t.validateTransactions([
           function() { return t.hong.mgmtIssueBountyToken(recipeint, bountyTokensToIssue, {from: ownerAddress}); },
-          function() { 
+          function() {
             t.assertEqualN(previousBalance + bountyTokensToIssue, t.hong.balanceOf(recipeint), done, "bounty issued");
             t.assertEqualN(previousBountyTokens + bountyTokensToIssue, t.hong.bountyTokensCreated(), done, "bounty tokens created");
           }
         ], done);
     });
   });
-  
+
   describe("mgmt only", function() {
     it ('does not allow others to call mgmtDistribute', function(done) {
       console.log('[does not allow others to call mgmtDistribute]');
@@ -391,13 +391,13 @@ describe('HONG Contract Suite', function() {
         ], done);
     });
   });
-  
+
   describe("kick off voting", function() {
     it ('does not allow non-token holder to vote kickoff', function(done) {
       console.log('[does not allow non-token holder to voteKickoff]');
       var fiscalYear = t.hong.currentFiscalYear()+1;
       var nonTokenHolder = users.fellow6;
-      
+
       done = t.assertEventIsFiredByName(t.hong.evRecord(), done, "onlyTokenHolders");
       t.validateTransactions([
           function() { return t.hong.voteToKickoffFund({from: nonTokenHolder})},
@@ -406,18 +406,18 @@ describe('HONG Contract Suite', function() {
           }
         ], done);
     });
-    
+
     it ('allows token holder to vote kickoff', function(done) {
       console.log('[allows token holder to vote kickoff]');
       var fiscalYear = t.hong.currentFiscalYear()+1;
-      
+
       var tokens1 = t.asNumber(t.hong.balanceOf(users.fellow1));
       var tokens2 = t.asNumber(t.hong.balanceOf(users.fellow2));
-      
+
       var getQuorumCount = function() { return t.hong.supportKickoffQuorum(fiscalYear) };
       var wasVoteSuccessful = function() { return t.hong.isInitialKickoffEnabled()};
       var vote = function(params) { return t.hong.voteToKickoffFund(params) };
-      
+
       done = t.logEventsToConsole(done);
       t.validateTransactions([
           function() { return vote({from: users.fellow1})},
@@ -425,7 +425,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqualN(tokens1, getQuorumCount(), done, "voted quorum count");
             t.assertEqual(false, wasVoteSuccessful() , done, "not successful");
           },
-          
+
           // verify additional vote has no effect
           function() { return vote({from: users.fellow1})},
           function() {
@@ -434,58 +434,58 @@ describe('HONG Contract Suite', function() {
           },
 
           function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
-          function() { 
+          function() {
             console.log("Validating fellow 1 transers tokens to fellow2, votes are reverted ...")
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
             t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
             t.assertEqualN(0, getQuorumCount(), done, "vote count");
           },
-          
+
           function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
-          function() { 
+          function() {
             console.log("Validating fellow 2 transers tokens back to fellow1 ...")
             t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
             t.assertEqualN(0, getQuorumCount(), done, "vote count");
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
-          
+
           function() { return vote({from: users.fellow1})},
-          function() { 
+          function() {
             console.log("Validating fellow 1 votes again after getting tokens back ...")
             var expectedVotes = tokens1;
             t.assertEqualN(expectedVotes, getQuorumCount(), done, "vote count");
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
-          
+
           /* Fellow 2 votes to kickoff */
           function() { return vote({from: users.fellow2})},
-          function() { 
+          function() {
             console.log("Validating fellow 2 voted...")
             var expectedVotes = tokens1 + tokens2;
             t.assertEqualN(expectedVotes, getQuorumCount(), done, "vote count");
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
-          
+
           function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
-          function() { 
+          function() {
             console.log("Validating fellow 1 transers tokens to fellow2, votes are reverted ...")
             t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
             t.assertEqualN(tokens1 + tokens2, t.hong.balanceOf(users.fellow2), done, "fellow 2 tokens");
             t.assertEqualN(tokens2, getQuorumCount(), done, "vote count");
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
-          
+
           /* Fellow 2 votes to kickoff after getting more tokens  */
           function() { return vote({from: users.fellow2})},
-          function() { 
+          function() {
             console.log("Validating fellow 2 votes again after getting more tokens...")
             var expectedVotes = tokens1 + tokens2;
             t.assertEqualN(expectedVotes, getQuorumCount(), done, "vote count");
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
-          
+
           function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
-          function() { 
+          function() {
             console.log("Validation fellow 2 gives fellow1 his tokens back ...")
             t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
             t.assertEqualN(tokens2, t.hong.balanceOf(users.fellow2), done, "fellow 2 tokens");
@@ -494,25 +494,25 @@ describe('HONG Contract Suite', function() {
           }
         ], done);
     });
-    
+
     it ('does kickoff when quorum is reached', function(done){
       console.log('[does kickoff when quorum is reached]');
       var tokenHolder = users.fellow5;
       var previousHongBalance = sandbox.web3.toBigNumber(t.hong.actualBalance());
       var previousExtraBalance = sandbox.web3.toBigNumber(t.getWalletBalance(t.hong.extraBalanceWallet()));
       var previousMgmtBodyBalance = sandbox.web3.toBigNumber(t.getWalletBalance(ownerAddress));
-      
+
       var contractBalance = previousExtraBalance.plus(previousHongBalance);
       var mgmtFeePercentage = t.asNumber(t.hong.mgmtFeePercentage());
       var totalMgmtFee =  contractBalance.times(mgmtFeePercentage).dividedBy(100).floor();
       var expectedMgmtFeeBalance = totalMgmtFee.times(6).dividedBy(8).floor();
       var expectedMgmtBodyPayment = totalMgmtFee.times(2).dividedBy(8).floor();
       var expectedMgmtBodyBalance = previousMgmtBodyBalance.plus(expectedMgmtBodyPayment);
-      
+
       done = t.logEventsToConsole(done);
       done = t.logAddressMessagesToConsole(done, t.hong.managementFeeWallet());
       t.validateTransactions([
-          function() { 
+          function() {
             return t.hong.voteToKickoffFund({from: tokenHolder});
           },
           function() {
@@ -524,7 +524,7 @@ describe('HONG Contract Suite', function() {
           }
         ], done);
     });
-    
+
     it ('does not allow harvest in FY1', function(done) {
       done = t.logEventsToConsole(done);
       done = t.assertEventIsFiredByName(t.hong.evRecord(), done, "currentFiscalYear<4");
@@ -535,7 +535,7 @@ describe('HONG Contract Suite', function() {
         }
         ], done);
     });
-    
+
     it ('can kickoff FY2', function(done) {
       t.sleepFor(kickoffDelay)
       done = t.logEventsToConsole(done);
@@ -548,7 +548,7 @@ describe('HONG Contract Suite', function() {
         },
         ], done);
     });
-    
+
     it ('can kickoff FY3', function(done) {
       t.sleepFor(kickoffDelay)
       done = t.logEventsToConsole(done);
@@ -561,7 +561,7 @@ describe('HONG Contract Suite', function() {
         },
         ], done);
     });
-    
+
     it ('can kickoff FY4', function(done) {
       t.sleepFor(kickoffDelay)
       done = t.logEventsToConsole(done);
@@ -574,7 +574,7 @@ describe('HONG Contract Suite', function() {
         },
         ], done);
     });
-    
+
     it ('cannot kickoff FY5', function(done) {
       t.sleepFor(kickoffDelay)
       done = t.logEventsToConsole(done);
@@ -588,11 +588,11 @@ describe('HONG Contract Suite', function() {
         },
         ], done);
     });
-    
+
     it ('does not allow non-token holder to vote harvest', function(done) {
       console.log('[does not allow non-token holder to vote harvest]');
       var nonTokenHolder = users.fellow6;
-      
+
       done = t.assertEventIsFiredByName(t.hong.evRecord(), done, "onlyTokenHolders");
       t.validateTransactions([
           function() { return t.hong.voteToHarvestFund({from: nonTokenHolder})},
@@ -601,16 +601,16 @@ describe('HONG Contract Suite', function() {
           }
         ], done);
     });
-    
+
     it ('allows token holders to harvest in FY4 and handles token transfer', function(done) {
       console.log('[allows token holder to vote harvest and handles token transfer]');
       var tokens1 = t.asNumber(t.hong.balanceOf(users.fellow1));
       var tokens2 = t.asNumber(t.hong.balanceOf(users.fellow2));
-      
+
       var getQuorumCount = function() { return t.hong.supportHarvestQuorum() };
       var wasVoteSuccessful = function() { return t.hong.isHarvestEnabled()};
       var vote = function(params) { return t.hong.voteToHarvestFund(params) };
-      
+
       done = t.logEventsToConsole(done);
       t.validateTransactions([
           function() { return vote({from: users.fellow1})},
@@ -618,7 +618,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqualN(tokens1, getQuorumCount(), done, "voted quorum count");
             t.assertEqual(false, wasVoteSuccessful() , done, "not successful");
           },
-          
+
           // verify additional vote has no effect
           function() { return vote({from: users.fellow1})},
           function() {
@@ -628,50 +628,50 @@ describe('HONG Contract Suite', function() {
           },
 
           function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
-          function() { 
+          function() {
             console.log("Validating fellow 1 transers tokens to fellow2, votes are reverted ...")
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
             t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
             t.assertEqualN(0, getQuorumCount(), done, "vote count");
           },
-          
+
           function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
-          function() { 
+          function() {
             console.log("Validating fellow 2 transers tokens back to fellow1 ...")
             t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
             t.assertEqualN(0, getQuorumCount(), done, "vote count");
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
-          
+
           function() { return vote({from: users.fellow1})},
-          function() { 
+          function() {
             console.log("Validating fellow 1 votes again after getting tokens back ...")
             var expectedVotes = tokens1;
             t.assertEqualN(expectedVotes, getQuorumCount(), done, "vote count");
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
-          
+
           /* Fellow 2 votes to harvest */
           function() { return vote({from: users.fellow2})},
-          function() { 
+          function() {
             console.log("Validating fellow 2 voted...")
             var expectedVotes = tokens1 + tokens2;
             t.assertEqualN(expectedVotes, getQuorumCount(), done, "vote count");
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
-          
+
           function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
-          function() { 
+          function() {
             console.log("Validating fellow 1 transers tokens to fellow2, votes are reverted ...")
             t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
             t.assertEqualN(tokens1 + tokens2, t.hong.balanceOf(users.fellow2), done, "fellow 2 tokens");
             t.assertEqualN(tokens2, getQuorumCount(), done, "vote count");
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
-          
+
           /* Fellow 2 votes to harvest after getting more tokens  */
           function() { return vote({from: users.fellow2})},
-          function() { 
+          function() {
             console.log("Validating fellow 2 votes again after getting more tokens...")
             var expectedVotes = tokens1 + tokens2;
             t.assertEqualN(expectedVotes, getQuorumCount(), done, "vote count");
@@ -679,7 +679,7 @@ describe('HONG Contract Suite', function() {
           },
 
           function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
-          function() { 
+          function() {
             console.log("Validation fellow 2 gives fellow1 his tokens back ...")
             t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
             t.assertEqualN(tokens2, t.hong.balanceOf(users.fellow2), done, "fellow 2 tokens");
@@ -688,7 +688,7 @@ describe('HONG Contract Suite', function() {
           }
         ], done);
     });
-    
+
     it ('does not allow mggmtBody to call mgmtDistribute before harvest is enabled', function(done) {
       done = t.logEventsToConsole(done);
       done = t.assertEventIsFiredByName(t.hong.evRecord(), done, "onlyHarvestEnabled");
@@ -699,7 +699,7 @@ describe('HONG Contract Suite', function() {
         }
         ], done);
     });
-    
+
     it ('triggers harvest when quorum is reached', function(done) {
       done = t.logEventsToConsole(done);
       done = t.assertEventIsFired(t.hong.evHarvest(), done);
@@ -707,17 +707,17 @@ describe('HONG Contract Suite', function() {
       t.validateTransactions([
         function() { return t.hong.voteToHarvestFund({from: users.fellow2})},
         function() { },
-        
+
         function() { return t.hong.voteToHarvestFund({from: users.fellow3})},
         function() { },
-        
+
         function() { return t.hong.voteToHarvestFund({from: users.fellow5})},
-        function() { 
-          t.assertEqual(true, t.hong.isHarvestEnabled(), done, "harvest enabled");       
+        function() {
+          t.assertEqual(true, t.hong.isHarvestEnabled(), done, "harvest enabled");
         },
         ], done);
     });
-    
+
     it ('does not allow non-owner to call mgmtDistribut', function(done) {
       done = t.logEventsToConsole(done);
       done = t.assertEventIsFiredByName(t.hong.evRecord(), done, "onlyManagementBody");
@@ -728,23 +728,23 @@ describe('HONG Contract Suite', function() {
         }
         ], done);
     });
-    
+
     it ('allows mgmtDistribute by mgmtBody after harvest is enabled', function(done) {
       done = t.logEventsToConsole(done);
       done = t.assertEventIsFired(t.hong.evMgmtDistributed(), done);
-      
+
       var hongBalance = t.asBigNumber(t.hong.actualBalance());
       var extraBalance = t.asBigNumber(t.getWalletBalance(t.hong.extraBalanceWallet()));
       var mgmtFeeWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.managementFeeWallet()));
-      var returnWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.returnWallet())); 
-      var rewardWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.rewardWallet())); 
-      
+      var returnWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.returnWallet()));
+      var rewardWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.rewardWallet()));
+
       var totalFunds = returnWalletBalance
                         .plus(hongBalance)
                         .plus(extraBalance)
                         .plus(mgmtFeeWalletBalance)
                         .plus(rewardWalletBalance);
-                        
+
       var mgmtRewardFraction = t.hong.mgmtRewardPercentage() / 100;
       var expectedMgmtReward = totalFunds.times(mgmtRewardFraction).floor();
       var expectedReturnWalletBalance = totalFunds.minus(expectedMgmtReward);
@@ -757,11 +757,11 @@ describe('HONG Contract Suite', function() {
         }
         ], done);
     });
-    
+
   });
-  
-  
-  
+
+
+
   function checkPriceForTokens(done, buyer, ethToSend, expectedTokens) {
     console.log("[checking token price, expecting " + ethToSend + " for " + expectedTokens + " tokens]");
     done = t.logEventsToConsole(done);

--- a/test/scenario1/scenario1_test.js
+++ b/test/scenario1/scenario1_test.js
@@ -433,7 +433,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
 
-          function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
+          function() { return t.hong.transfer(users.fellow2, tokens1, {from: users.fellow1})},
           function() {
             console.log("Validating fellow 1 transers tokens to fellow2, votes are reverted ...")
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
@@ -441,7 +441,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqualN(0, getQuorumCount(), done, "vote count");
           },
 
-          function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
+          function() { return t.hong.transfer(users.fellow1, tokens1, {from: users.fellow2})},
           function() {
             console.log("Validating fellow 2 transers tokens back to fellow1 ...")
             t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
@@ -466,7 +466,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
 
-          function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
+          function() { return t.hong.transfer(users.fellow2, tokens1, {from: users.fellow1})},
           function() {
             console.log("Validating fellow 1 transers tokens to fellow2, votes are reverted ...")
             t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
@@ -484,7 +484,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
 
-          function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
+          function() { return t.hong.transfer(users.fellow1, tokens1, {from: users.fellow2})},
           function() {
             console.log("Validation fellow 2 gives fellow1 his tokens back ...")
             t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
@@ -627,7 +627,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
 
-          function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
+          function() { return t.hong.transfer(users.fellow2, tokens1, {from: users.fellow1})},
           function() {
             console.log("Validating fellow 1 transers tokens to fellow2, votes are reverted ...")
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
@@ -635,7 +635,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqualN(0, getQuorumCount(), done, "vote count");
           },
 
-          function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
+          function() { return t.hong.transfer(users.fellow1, tokens1, {from: users.fellow2})},
           function() {
             console.log("Validating fellow 2 transers tokens back to fellow1 ...")
             t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
@@ -660,7 +660,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
 
-          function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
+          function() { return t.hong.transfer(users.fellow2, tokens1, {from: users.fellow1})},
           function() {
             console.log("Validating fellow 1 transers tokens to fellow2, votes are reverted ...")
             t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
@@ -678,7 +678,7 @@ describe('HONG Contract Suite', function() {
             t.assertEqual(false, wasVoteSuccessful(), done, "not successful");
           },
 
-          function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
+          function() { return t.hong.transfer(users.fellow1, tokens1, {from: users.fellow2})},
           function() {
             console.log("Validation fellow 2 gives fellow1 his tokens back ...")
             t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");

--- a/test/scenario2/scenario2_test.js
+++ b/test/scenario2/scenario2_test.js
@@ -14,27 +14,27 @@ describe('Scenario 2: HONG Contract Suite', function() {
   this.timeout(60000);
   sandbox = new Sandbox('http://localhost:8552');
   compiled = sc.compile(helper, "HongCoin.sol");
-  
+
   before(function(done) {
-    sandbox.start(__dirname + '/../ethereum.json', done);  
+    sandbox.start(__dirname + '/../ethereum.json', done);
   });
 
   it('test-deploy', function(done) {
     var endDate = Date.now() / 1000 + timeTillClosing;
     eth = sandbox.web3.toWei(1, 'ether');
     console.log(' [test-deploy]');
-    
+
     t.sandbox = sandbox;
     t.ownerAddress = users.fellow1;
     t.helper = helper;
     t.createContract(compiled, done, endDate);
   });
-  
+
   it('locks fund if minTokens is reached before closingTime', function(done) {
-    
+
     t.validateTransactions([
       function() { return t.buyTokens(users.fellow1, 200000*eth)},
-      function() { 
+      function() {
         console.log(t.hong.tokensCreated());
         t.assertEqual(false, t.hong.isMinTokensReached(), done, "min tokens reached")
       },
@@ -56,7 +56,7 @@ describe('Scenario 2: HONG Contract Suite', function() {
         t.assertEqual(true, t.hong.isFundLocked(), done, "is fund locked");
       }], done);
   });
-    
+
   after(function(done) {
     console.log("Shutting down sandbox");
     sandbox.stop(done);

--- a/test/scenario3/scenario3_test.js
+++ b/test/scenario3/scenario3_test.js
@@ -35,12 +35,12 @@ describe('Scenario 3: HONG Contract Suite', function() {
     t.helper = helper;
     t.createContract(compiled, done, endDate, extensionPeriod, lastKickoffDateBuffer);
   });
-  
+
   it('locks fund if minTokens is reached after closingTime but before extensions period', function(done) {
     var secondClosingTime = t.asNumber(t.hong.closingTime()) + t.asNumber(t.hong.closingTimeExtensionPeriod());
     t.validateTransactions([
       function() { return t.buyTokens(users.fellow1, ethToWei(200000))},
-      function() { 
+      function() {
         console.log(t.hong.tokensCreated());
         t.assertEqual(false, t.hong.isMinTokensReached(), done, "min tokens reached")
       },
@@ -66,7 +66,7 @@ describe('Scenario 3: HONG Contract Suite', function() {
       },
       function() {
         t.sleepUntil(secondClosingTime);
-        return t.buyTokens(users.fellow5, 1*eth); 
+        return t.buyTokens(users.fellow5, 1*eth);
       },
       function() {
         t.assertEqual(false, t.hong.isMaxTokensReached(), done, "max tokens reached");
@@ -75,7 +75,7 @@ describe('Scenario 3: HONG Contract Suite', function() {
       }
       ], done);
   });
-    
+
   after(function(done) {
     console.log("Shutting down sandbox");
     sandbox.stop(done);

--- a/test/scenario4/scenario4_test.js
+++ b/test/scenario4/scenario4_test.js
@@ -38,27 +38,27 @@ describe('Scenario 4: MinTokens never reached', function() {
     t.helper = helper;
     t.createContract(compiled, done, endDate, extensionPeriod, lastKickoffDateBuffer);
   });
-  
+
   it('locks fund if minTokens is reached after closingTime but before extensions period', function(done) {
     console.log(' [locks fund if minTokens is reached after closingTime but before extensions period]');
     var secondClosingTime = t.asNumber(t.hong.closingTime()) + t.asNumber(t.hong.closingTimeExtensionPeriod());
     done = t.logEventsToConsole(done);
     done = t.assertEventIsFired(t.hong.evReleaseFund(), done);
-    
+
     var purchase1 = sandbox.web3.toBigNumber(ethToWei(10));
     var purchase2 = sandbox.web3.toBigNumber(ethToWei(200000));
     var purchase3 = sandbox.web3.toBigNumber(ethToWei(2));
-    
+
     fellow1OriginalBalance = t.asBigNumber(t.getWalletBalance(users.fellow1));
     fellow4OriginalBalance = t.asBigNumber(t.getWalletBalance(users.fellow4));
     fellow5OriginalBalance = t.asBigNumber(t.getWalletBalance(users.fellow5));
-    
+
     t.validateTransactions([
       function() { return t.buyTokens(users.fellow1, purchase1)},
-      function() { 
+      function() {
         t.assertEqual(false, t.hong.isMinTokensReached(), done, "min tokens reached");
       },
-      
+
       function() {
         t.sleepUntil(t.hong.closingTime());
         return t.buyTokens(users.fellow4, purchase2)
@@ -68,7 +68,7 @@ describe('Scenario 4: MinTokens never reached', function() {
       function() {
         // after the second closing time, buy some tokens to trigger the check, but not enough to reach minTokens
         t.sleepUntil(secondClosingTime);
-        return t.buyTokens(users.fellow5, purchase3) 
+        return t.buyTokens(users.fellow5, purchase3)
       },
       function() {
         t.assertEqual(false, t.hong.isMinTokensReached(), done, "min tokens reached (3)");
@@ -76,7 +76,7 @@ describe('Scenario 4: MinTokens never reached', function() {
       }
       ], done);
   });
-  
+
   it('no more tokens will be sold once the fund is released', function(done) {
     console.log(' [no more tokens will be sold once the fund is released]');
     var buyer = users.fellow7;
@@ -89,14 +89,14 @@ describe('Scenario 4: MinTokens never reached', function() {
       }
       ], done);
   });
-    
+
   it('allows users to get a refund', function(done) {
     done = t.logEventsToConsole(done);
-    
+
     t.assertTrue(t.asNumber(t.hong.balanceOf(users.fellow1)) > 0, done, "fellow1 has tokens");
     t.assertTrue(t.asNumber(t.hong.balanceOf(users.fellow4)) > 0, done, "fellow4 has tokens");
     t.assertTrue(t.asNumber(t.hong.balanceOf(users.fellow5)) > 0, done, "fellow5 has tokens");
-    
+
     t.validateTransactions([
       function() { return t.hong.refundMyIcoInvestment({from : users.fellow1}); },
       function() {
@@ -104,23 +104,23 @@ describe('Scenario 4: MinTokens never reached', function() {
         t.assertEqualB(fellow1OriginalBalance, newBalance, done, "fellow1 balance");
         t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow1 token count");
       },
-      
+
       function() { return t.hong.refundMyIcoInvestment({from : users.fellow4}); },
       function() {
         var newBalance = t.asBigNumber(t.getWalletBalance(users.fellow4));
         t.assertTrue(fellow4OriginalBalance, newBalance, done, "fellow4 balance");
         t.assertEqualN(0, t.hong.balanceOf(users.fellow4), done, "fellow4 token count");
       },
-      
+
       function() { return t.hong.refundMyIcoInvestment({from : users.fellow5}); },
-      function() {  
+      function() {
         var newBalance = t.asBigNumber(t.getWalletBalance(users.fellow5));
         t.assertTrue(fellow5OriginalBalance, newBalance, done, "fellow5 balance");
         t.assertEqualN(0, t.hong.balanceOf(users.fellow5), done, "fellow5 token count");
       }
       ], done);
   });
-    
+
   after(function(done) {
     console.log("Shutting down sandbox");
     sandbox.stop(done);

--- a/test/scenario5_freeze/scenario5_test.js
+++ b/test/scenario5_freeze/scenario5_test.js
@@ -104,7 +104,7 @@ describe(scenario, function() {
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
 
-      function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
+      function() { return t.hong.transfer(users.fellow2, tokens1, {from: users.fellow1})},
       function() {
         console.log("Validating fellow 1 transers tokens to fellow2, freeze votes are reverted ...")
         t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
@@ -112,7 +112,7 @@ describe(scenario, function() {
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
 
-      function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
+      function() { return t.hong.transfer(users.fellow1, tokens1, {from: users.fellow2})},
       function() {
         console.log("Validating fellow 2 transers tokens back to fellow1 ...")
         t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
@@ -137,7 +137,7 @@ describe(scenario, function() {
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
 
-      function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
+      function() { return t.hong.transfer(users.fellow2, tokens1, {from: users.fellow1})},
       function() {
         console.log("Validating fellow 1 transers tokens to fellow2, freeze votes are reverted ...")
         t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");

--- a/test/scenario5_freeze/scenario5_test.js
+++ b/test/scenario5_freeze/scenario5_test.js
@@ -16,35 +16,35 @@ describe(scenario, function() {
   this.timeout(60000);
   sandbox = new Sandbox('http://localhost:8552');
   compiled = sc.compile(helper, "HongCoin.sol");
-  
+
   before(function(done) {
-    sandbox.start(__dirname + '/../ethereum.json', done);  
+    sandbox.start(__dirname + '/../ethereum.json', done);
   });
 
   it('test-deploy', function(done) {
     var endDate = Date.now() / 1000 + timeTillClosing;
     eth = sandbox.web3.toWei(1, 'ether');
     console.log(' [test-deploy]');
-    
+
     t.sandbox = sandbox;
     t.ownerAddress = users.fellow1;
     t.helper = helper;
     t.createContract(compiled, done, endDate);
   });
-  
+
   it('Sets up ok', function(done) {
     console.log("Setting up the contract...");
     t.validateTransactions([
-      function() { return t.buyTokens(users.fellow1, 200000*eth)}, 
+      function() { return t.buyTokens(users.fellow1, 200000*eth)},
       nothingToAssert,
-      
-      function() { return t.buyTokens(users.fellow2, 200000*eth)}, 
+
+      function() { return t.buyTokens(users.fellow2, 200000*eth)},
       nothingToAssert,
-      
-      function() { return t.buyTokens(users.fellow3, 200000*eth)}, 
+
+      function() { return t.buyTokens(users.fellow3, 200000*eth)},
       nothingToAssert,
-      
-      function() { return t.buyTokens(users.fellow4, 200000*eth)}, 
+
+      function() { return t.buyTokens(users.fellow4, 200000*eth)},
       nothingToAssert,
 
       function() {
@@ -52,32 +52,32 @@ describe(scenario, function() {
         return t.buyTokens(users.fellow5, 300000*eth)
       },
       nothingToAssert,
-      
+
       function() {
         return t.hong.voteToKickoffFund({from: users.fellow1});
-      }, 
+      },
       nothingToAssert,
-      
+
       function() { return t.hong.voteToKickoffFund({from: users.fellow5});},
       function() {
         t.assertEqual(true, t.hong.isInitialKickoffEnabled(), done, "kickoff enable");
       }
-      ], 
+      ],
       done);
   });
-  
+
   it('freezes the fund when quorum is reached', function(done) {
     console.log(" [freezes the fund when quorum is reached]");
     var tokens1 = t.asNumber(t.hong.balanceOf(users.fellow1));
     var tokens2 = t.asNumber(t.hong.balanceOf(users.fellow2));
     var tokens3 = t.asNumber(t.hong.balanceOf(users.fellow3));
-    
+
     var hongBalance = t.asBigNumber(t.hong.actualBalance());
     var extraBalance = t.asBigNumber(t.getWalletBalance(t.hong.extraBalanceWallet()));
     var mgmtFeeWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.managementFeeWallet()));
-    var returnWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.returnWallet())); 
-    var rewardWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.rewardWallet())); 
-    
+    var returnWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.returnWallet()));
+    var rewardWalletBalance = t.asBigNumber(t.getWalletBalance(t.hong.rewardWallet()));
+
     var expectedReturnWalletBalance = returnWalletBalance
                                         .plus(hongBalance)
                                         .plus(extraBalance)
@@ -89,91 +89,91 @@ describe(scenario, function() {
     done = t.assertEventIsFired(t.hong.evFreeze(), done);
     t.validateTransactions([
       function() { return t.hong.voteToFreezeFund({from: users.fellow1})},
-      function() { 
+      function() {
         console.log("Validating fellow 1 voted to freeze...")
         var expectedVotes = tokens1;
         t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       function() { return t.hong.voteToFreezeFund({from: users.fellow1})},
-      function() { 
+      function() {
         console.log("Validating fellow 1 voted to freeze (duplicate vote) ...")
         var expectedVotes = tokens1;
         t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
-      function() { 
+      function() {
         console.log("Validating fellow 1 transers tokens to fellow2, freeze votes are reverted ...")
         t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
         t.assertEqualN(0, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       function() { return t.hong.transferMyTokens(users.fellow1, tokens1, {from: users.fellow2})},
-      function() { 
+      function() {
         console.log("Validating fellow 2 transers tokens back to fellow1 ...")
         t.assertEqualN(tokens1, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
         t.assertEqualN(0, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       function() { return t.hong.voteToFreezeFund({from: users.fellow1})},
-      function() { 
+      function() {
         console.log("Validating fellow 1 votes to freeze again after getting tokens back ...")
         var expectedVotes = tokens1;
         t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       /* Fellow 2 votes to freeze */
       function() { return t.hong.voteToFreezeFund({from: users.fellow2})},
-      function() { 
+      function() {
         console.log("Validating fellow 2 voted to freeze...")
         var expectedVotes = tokens1 + tokens2;
         t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       function() { return t.hong.transferMyTokens(users.fellow2, tokens1, {from: users.fellow1})},
-      function() { 
+      function() {
         console.log("Validating fellow 1 transers tokens to fellow2, freeze votes are reverted ...")
         t.assertEqualN(0, t.hong.balanceOf(users.fellow1), done, "fellow 1 tokens");
         t.assertEqualN(tokens1 + tokens2, t.hong.balanceOf(users.fellow2), done, "fellow 2 tokens");
         t.assertEqualN(tokens2, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       /* Fellow 2 votes to freeze after getting more tokens  */
       function() { return t.hong.voteToFreezeFund({from: users.fellow2})},
-      function() { 
+      function() {
         console.log("Validating fellow 2 votes to freeze again after getting more tokens...")
         var expectedVotes = tokens1 + tokens2;
         t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       /* Fellow 2 changes his mind */
       function() { return t.hong.voteToUnfreezeFund({from: users.fellow2})},
-      function() { 
+      function() {
         console.log("Validating fellow 2 voted to unfreeze...")
         t.assertEqualN(0, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       /* Fellow 2 votes to freeze again */
       function() { return t.hong.voteToFreezeFund({from: users.fellow2})},
-      function() { 
+      function() {
         console.log("Validating fellow 2 voted to freeze again...")
         var expectedVotes = tokens1 + tokens2;
         t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(false, t.hong.isFreezeEnabled(), done, "not frozen");
       },
-      
+
       function() { return t.hong.voteToFreezeFund({from: users.fellow3})},
-      function() { 
+      function() {
         console.log("Validating fellow 3 voted to freeze and fund is now frozen...")
         var expectedVotes = tokens1 + tokens2 + tokens3;
         t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
@@ -184,19 +184,19 @@ describe(scenario, function() {
         t.assertEqualN(0, t.getWalletBalance(t.hong.rewardWallet()), done, "reward wallet");
         t.assertEqualB(expectedReturnWalletBalance, t.asBigNumber(t.getWalletBalance(t.hong.returnWallet())), done, "retrun wallet");
       },
-      
+
       /* Fellow 2 changes his mind again, but now it's too late */
       function() { return t.hong.voteToUnfreezeFund({from: users.fellow2})},
-      function() { 
+      function() {
         console.log("Validating fellow 2 cannot unfreeze after the fund is frozen...")
         var expectedVotes = tokens1 + tokens2 + tokens3;
         t.assertEqualN(expectedVotes, t.hong.supportFreezeQuorum(), done, "freeze vote count");
         t.assertEqual(true, t.hong.isFreezeEnabled(), done, "still frozen");
       },
-      
+
       ], done);
   });
-  
+
   it('no more tokens will be sold once the fund is frozen', function(done) {
     console.log(' [no more tokens will be sold once the fund is released]');
     var buyer = users.fellow7;
@@ -209,21 +209,21 @@ describe(scenario, function() {
       }
       ], done);
   });
-  
+
   it('allows users to collect their return after freezing the fund', function(done) {
     console.log("[allows users to collect their return after freezing the fund]");
     done = t.logEventsToConsole(done);
-    
+
     var fellow1Shares = t.asBigNumber(t.hong.balanceOf(users.fellow1));
     var tokensCreated = t.asBigNumber(t.hong.tokensCreated());
     var bountyTokens = t.asBigNumber(t.hong.bountyTokensCreated());
-    
+
     var returnAccountBalance = t.asBigNumber(t.getWalletBalance(t.hong.returnWallet()));
     var expectedWeiPerToken = returnAccountBalance.dividedBy(tokensCreated.plus(bountyTokens)).floor();
     var fellow1Balance = t.asBigNumber(t.getWalletBalance(users.fellow1));
     var expectedReturn = fellow1Shares.times(expectedWeiPerToken);
     var expectedBalance = fellow1Balance.plus(expectedReturn);
-    
+
     t.validateTransactions([
         function() { return t.hong.collectMyReturn({from: users.fellow1 }); },
         function() {
@@ -232,7 +232,7 @@ describe(scenario, function() {
         }
       ], done);
   });
-  
+
   after(function(done) {
     console.log("Shutting down sandbox");
     sandbox.stop(done);

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,7 +4,7 @@ module.exports = {
   doLog: function(s) {
       console.log(s);
   },
-  
+
   sandbox: null,
   hong: null,
   ownerAddress: null,
@@ -13,7 +13,7 @@ module.exports = {
   minTokensToCreate: 100 * MILLION,
   maxTokensToCreate: 250 * MILLION,
   tokensPerTier: 50 * MILLION,
-  
+
   createContract : function (compiled, done, _endDate, _closingTimeExtensionPeriod, _lastKickoffDateBuffer) {
       var that = this;
       this.sandbox.web3.eth.contract(JSON.parse(compiled.contracts['HONG'].interface)).new(
@@ -25,7 +25,7 @@ module.exports = {
           {
             /* contract creator */
             from: this.ownerAddress,
-  
+
             /* contract bytecode */
             data: '0x' + compiled.contracts['HONG'].bytecode
           },
@@ -57,22 +57,22 @@ module.exports = {
 
   sleepUntil : function( deadline ){
     console.log("Sleeping for " + (deadline - this.now()) + "s");
-    while(this.now() < deadline){ /* do nothing */ } 
+    while(this.now() < deadline){ /* do nothing */ }
   },
-  
+
   // Return the time, but in seconds since epoch (since that's what ethereum uses)
   now : function() {
     return new Date().getTime()/1000;
   },
-  
+
   getWalletBalance : function(address) {
     return this.sandbox.web3.eth.getBalance(address);
   },
-  
-  buyTokens : function (buyer, wei) {  
+
+  buyTokens : function (buyer, wei) {
     return this.sandbox.web3.eth.sendTransaction({from: buyer, to: this.hong.address, gas: 900000, value: wei});
   },
-    
+
   logEventsToConsole : function (done) {
     var filter = this.hong.evRecord();
     filter.watch(function(err, val) {
@@ -105,7 +105,7 @@ module.exports = {
     };
     return newDone;
   },
-  
+
   assertEqualN: function (expected, actual, done, msg) {
     this.assertEqual(this.asNumber(expected), this.asNumber(actual), done, msg);
   },
@@ -172,7 +172,7 @@ module.exports = {
       }
     };
   },
-  
+
   purchaseAllTokensInTier : function (done, buyer, expectedFundLocked, extraTokens) {
     console.log("Purchasing the rest of the tokens in current tier, currentTier: " + this.hong.getCurrentTier());
     done = this.logEventsToConsole(done);
@@ -244,7 +244,7 @@ module.exports = {
           that.validateTransactions(txAndValidation, done);
       });
   },
-  
+
   printBalances : function() {
     console.log("-------");
     console.log("Hong: " + this.hong.actualBalance());


### PR DESCRIPTION
- Clean up space chars in js files
- Renamed `transferMyTokens` to `transfer` to solve the issue of cannot transfer token in Mist outside contract since it is a design in Ethereum contracts interface as a universal name. [See the reference](http://ethereum.stackexchange.com/questions/6932/what-function-does-ethereum-mist-wallet-use-to-send-custom-tokens)
