### PR TITLE
Adding testing flag to constructor, new unit test for funding projects

### DIFF
--- a/HongCoin.sol
+++ b/HongCoin.sol
@@ -45,10 +45,11 @@ contract HongConfiguration {
 }
 
 contract ErrorHandler {
+    bool public isInTestMode = false;
     event evRecord(address msg_sender, uint msg_value, string eventType, string message);
     function doThrow(string message) internal {
         evRecord(msg.sender, msg.value, "Error", message);
-        if(true){ // TODO some configurable parameter to switch whether it is in testing mode
+        if(!isInTestMode){
             throw;
         }
     }
@@ -602,7 +603,8 @@ contract HONG is HONGInterface, Token, TokenCreation {
         uint _lastKickoffDateBuffer,
         uint _minTokensToCreate,
         uint _maxTokensToCreate,
-        uint _tokensPerTier
+        uint _tokensPerTier,
+        bool _isInTestMode
     ) TokenCreation(_managementBodyAddress, _closingTime) {
 
         managementBodyAddress = _managementBodyAddress;
@@ -612,6 +614,7 @@ contract HONG is HONGInterface, Token, TokenCreation {
         minTokensToCreate = _minTokensToCreate;
         maxTokensToCreate = _maxTokensToCreate;
         tokensPerTier = _tokensPerTier;
+        isInTestMode = _isInTestMode;
 
         returnWallet = new ReturnWallet(managementBodyAddress);
         rewardWallet = new RewardWallet(address(returnWallet));

--- a/test/scenario1/scenario1_test.js
+++ b/test/scenario1/scenario1_test.js
@@ -524,7 +524,31 @@ describe('HONG Contract Suite', function() {
           }
         ], done);
     });
-
+    
+    it ('allows mgmt to invest in a project', function(done){
+      var testAmount = 100;
+      done = t.logEventsToConsole(done);
+      done = t.assertEventIsFired(t.hong.evMgmtInvestProject(), done, function(event) {
+        return event.result && event._amount == testAmount;
+      });
+      
+      var fellow7Balance = t.asBigNumber(t.getWalletBalance(users.fellow7));
+      var hongBalance = t.asBigNumber(t.hong.actualBalance());
+      
+      var expectedUserBalance = fellow7Balance.add(testAmount);
+      var expectedHongBalance = hongBalance.minus(testAmount);
+      
+      t.validateTransactions([
+        function(){ return t.hong.mgmtInvestProject(users.fellow7, testAmount);},
+        function(){
+          var actualUserBalance = t.asBigNumber(t.getWalletBalance(users.fellow7));
+          var actualHongBalance = t.asBigNumber(t.hong.actualBalance());
+          t.assertEqualB(expectedUserBalance, actualUserBalance, done, "expected user balance");
+          t.assertEqualB(expectedHongBalance, actualHongBalance, done, "expected hong balance");
+        }
+        ], done);
+    });
+    
     it ('does not allow harvest in FY1', function(done) {
       done = t.logEventsToConsole(done);
       done = t.assertEventIsFiredByName(t.hong.evRecord(), done, "currentFiscalYear<4");

--- a/test/utils.js
+++ b/test/utils.js
@@ -22,6 +22,7 @@ module.exports = {
           _closingTimeExtensionPeriod,
           _lastKickoffDateBuffer,
           this.minTokensToCreate, this.maxTokensToCreate, this.tokensPerTier,
+          true,
           {
             /* contract creator */
             from: this.ownerAddress,


### PR DESCRIPTION
This will allow us to deploy two versions for testing.  One that logs events for debugging and one that actually throws (which is what we will do in production).  Unit tests don't yet cover the case where we actually throw, but we should be able to.  Ideally, the tests would set the expectation based on the setting, so it would work either way.
